### PR TITLE
Patch 3.0.7

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ description = "A performance friendly way to sort your items"
 
 repositories {
     mavenCentral()
-    maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     `java-library`
     `maven-publish`
     signing
-    id("xyz.jpenilla.run-paper") version "2.2.2"
+    id("xyz.jpenilla.run-paper") version "2.3.1"
     id("net.minecrell.plugin-yml.paper") version "0.6.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import net.minecrell.pluginyml.bukkit.BukkitPluginDescription
-import net.minecrell.pluginyml.paper.PaperPluginDescription
 
 plugins {
     `java-library`
@@ -12,7 +11,7 @@ plugins {
 runPaper.folia.registerTask()
 
 group = "de.kwantux"
-version = "3.0.6"
+version = "3.0.7"
 description = "A performance friendly way to sort your items"
 
 repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/kwantux/networks/Main.java
+++ b/src/main/java/de/kwantux/networks/Main.java
@@ -1,26 +1,19 @@
 package de.kwantux.networks;
 
+import de.kwantux.config.lang.LanguageController;
+import de.kwantux.manual.Manual;
 import de.kwantux.networks.commands.NetworksCommandManager;
 import de.kwantux.networks.component.util.FilterTranslator;
-import de.kwantux.networks.event.NoticeListener;
+import de.kwantux.networks.config.Config;
+import de.kwantux.networks.config.CraftingManager;
+import de.kwantux.networks.event.*;
 import de.kwantux.networks.utils.DoubleChestUtils;
 import de.kwantux.networks.utils.FoliaUtils;
 import de.kwantux.networks.utils.Metrics;
-import de.kwantux.config.lang.LanguageController;
-import de.kwantux.manual.Manual;
-import de.kwantux.networks.config.Config;
-import de.kwantux.networks.config.CraftingManager;
-import de.kwantux.networks.event.BlockBreakListener;
-import de.kwantux.networks.event.BlockPlaceListener;
-import de.kwantux.networks.event.ComponentListener;
-import de.kwantux.networks.event.WandListener;
-import de.kwantux.networks.event.PlayerJoinListener;
 import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
 import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
 import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.incendo.cloud.paper.PaperCommandManager;
-import org.incendo.cloud.paper.util.sender.Source;
 import org.spongepowered.configurate.serialize.SerializationException;
 
 import java.io.IOException;
@@ -132,7 +125,7 @@ public final class Main extends JavaPlugin {
 
         if (FoliaUtils.folia) {
             logger.warning("Folia support on Networks is still in beta, please report any bugs.");
-            for (int i : cfg.getMaxRanges()) {
+            for (int i : Config.ranges) {
                 if (i > 1000) {
                     logger.warning("You are running Networks on Folia and enabled a maximum network range of more than 1000 blocks. Be aware that on Folia, you might not be able to transmit items that far.");
                     break;

--- a/src/main/java/de/kwantux/networks/Manager.java
+++ b/src/main/java/de/kwantux/networks/Manager.java
@@ -11,6 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.persistence.PersistentDataContainer;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -155,7 +156,7 @@ public final class Manager implements de.kwantux.networks.api.Manager {
      * @return The component at that location, null if there is no component at that location
      */
     @Override
-    public NetworkComponent getComponent(BlockLocation location) {
+    public NetworkComponent getComponent(@NotNull BlockLocation location) {
         Network network = getNetworkWithComponent(location);
         if (network == null) return null;
         return network.getComponent(location);
@@ -166,7 +167,7 @@ public final class Manager implements de.kwantux.networks.api.Manager {
      * @return
      */
     @Override
-    public Network getNetworkWithComponent(BlockLocation location) {
+    public Network getNetworkWithComponent(@NotNull BlockLocation location) {
         Network network = null;
         for (BlockLocation loc : locations.keySet()) {
             if (location.equals(loc)) {

--- a/src/main/java/de/kwantux/networks/Sorter.java
+++ b/src/main/java/de/kwantux/networks/Sorter.java
@@ -1,14 +1,8 @@
 package de.kwantux.networks;
 
-import de.kwantux.networks.component.module.Acceptor;
-import de.kwantux.networks.component.module.BaseModule;
-import de.kwantux.networks.component.module.Donator;
-import de.kwantux.networks.component.module.Requestor;
-import de.kwantux.networks.component.module.Supplier;
-import de.kwantux.networks.utils.FoliaUtils;
-import de.kwantux.networks.config.Config;
-import de.kwantux.networks.storage.InterThreadTransmissionController;
 import de.kwantux.networks.component.module.*;
+import de.kwantux.networks.config.Config;
+import de.kwantux.networks.utils.FoliaUtils;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
@@ -20,32 +14,28 @@ import static de.kwantux.networks.Main.logger;
 public class Sorter {
 
     private static Integer[] ranges;
-    private static boolean ittc = false;
 
     public static void setConfig(@Nonnull Config config) {
         ranges = config.getMaxRanges();
     }
 
-    public static void transmit(@Nonnull ItemStack stack, BaseModule source, BaseModule target) {
-        if (ittc) {
-            InterThreadTransmissionController.transmit(stack, source, target);
-        }
-        else {
-            source.inventory().remove(stack);
-            target.inventory().addItem(stack);
-        }
+    public static synchronized void transmit(@Nonnull ItemStack stack, BaseModule source, BaseModule target) {
+        source.inventory().removeItem(stack);
+        target.inventory().addItem(stack);
     }
 
-    public static void donate(Network network, Donator donator) {
+    public static synchronized void donate(Network network, Donator donator) {
         List<? extends Acceptor> acceptors = network.acceptors();
         for (ItemStack item : donator.donate()) {
             if (item == null) continue;
             try {
                 for (Acceptor acceptor : acceptors) {
-                    if (acceptor.ready() && inDistance(network,donator, acceptor) && Acceptor.spaceFree(acceptor.inventory(), item) && acceptor.accept(item)) {
-                        transmit(item, donator, acceptor);
-                        break;
-                    }
+                    if (!(acceptor.ready() && inDistance(network,donator,acceptor))) continue;
+                    if (!acceptor.accept(item)) continue;
+                    if (!Acceptor.spaceFree(acceptor.inventory(), item)) continue;
+                    System.out.println("SPACE FREE");
+                    transmit(item, donator, acceptor);
+                    break;
                 }
             }
             catch (Throwable e) {
@@ -55,7 +45,7 @@ public class Sorter {
         }
     }
 
-    public static void request(Network network, Requestor requestor) {
+    public static synchronized void request(Network network, Requestor requestor) {
         List<? extends Supplier> suppliers = network.suppliers();
         for (ItemStack item : requestor.requested()) {
             if (item == null) continue;

--- a/src/main/java/de/kwantux/networks/Sorter.java
+++ b/src/main/java/de/kwantux/networks/Sorter.java
@@ -32,7 +32,7 @@ public class Sorter {
                 for (Acceptor acceptor : acceptors) {
                     if (!(acceptor.ready() && inDistance(network,donator,acceptor))) continue;
                     if (!acceptor.accept(item)) continue;
-                    if (!Acceptor.spaceFree(acceptor.inventory(), item)) continue;
+                    if (!acceptor.spaceFree(item)) continue;
                     System.out.println("SPACE FREE");
                     transmit(item, donator, acceptor);
                     break;

--- a/src/main/java/de/kwantux/networks/Sorter.java
+++ b/src/main/java/de/kwantux/networks/Sorter.java
@@ -1,7 +1,6 @@
 package de.kwantux.networks;
 
 import de.kwantux.networks.component.module.*;
-import de.kwantux.networks.config.Config;
 import de.kwantux.networks.utils.FoliaUtils;
 import org.bukkit.inventory.ItemStack;
 
@@ -10,14 +9,9 @@ import java.util.List;
 import java.util.logging.Level;
 
 import static de.kwantux.networks.Main.logger;
+import static de.kwantux.networks.config.Config.ranges;
 
 public class Sorter {
-
-    private static Integer[] ranges;
-
-    public static void setConfig(@Nonnull Config config) {
-        ranges = config.getMaxRanges();
-    }
 
     public static synchronized void transmit(@Nonnull ItemStack stack, BaseModule source, BaseModule target) {
         source.inventory().removeItem(stack);

--- a/src/main/java/de/kwantux/networks/commands/NetworksCommand.java
+++ b/src/main/java/de/kwantux/networks/commands/NetworksCommand.java
@@ -2,6 +2,9 @@ package de.kwantux.networks.commands;
 
 import de.kwantux.config.ConfigurationManager;
 import de.kwantux.config.util.exceptions.InvalidNodeException;
+import de.kwantux.manual.ManualManager;
+import de.kwantux.networks.Main;
+import de.kwantux.networks.Network;
 import de.kwantux.networks.component.ComponentType;
 import de.kwantux.networks.component.NetworkComponent;
 import de.kwantux.networks.component.component.InputContainer;
@@ -14,13 +17,9 @@ import de.kwantux.networks.utils.BlockLocation;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.TextColor;
-import de.kwantux.manual.ManualManager;
-import de.kwantux.networks.Main;
-import de.kwantux.networks.Network;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -29,13 +28,7 @@ import org.incendo.cloud.context.CommandContext;
 import org.incendo.cloud.setting.ManagerSetting;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static de.kwantux.networks.Main.*;
@@ -231,7 +224,7 @@ public class NetworksCommand extends CommandHandler {
                 .literal("give")
                 .literal("upgrade")
                 .literal("range")
-                .required("tier", integerParser(1, cfg.getMaxRanges().length))
+                .required("tier", integerParser(1, Config.ranges.length))
                 .permission("networks.give")
                 .senderType(Player.class)
                 .handler(this::giveUpgradeRange)

--- a/src/main/java/de/kwantux/networks/component/module/Acceptor.java
+++ b/src/main/java/de/kwantux/networks/component/module/Acceptor.java
@@ -22,7 +22,7 @@ public interface Acceptor extends PassiveModule {
             }
             return false;
         }
-        else return inv.firstEmpty() != -1;
+        return inv.firstEmpty() != -1;
     }
 
     int acceptorPriority();

--- a/src/main/java/de/kwantux/networks/component/module/Acceptor.java
+++ b/src/main/java/de/kwantux/networks/component/module/Acceptor.java
@@ -25,6 +25,10 @@ public interface Acceptor extends PassiveModule {
         return inv.firstEmpty() != -1;
     }
 
+    default boolean spaceFree(ItemStack stack) {
+        return spaceFree(inventory(), stack);
+    }
+
     int acceptorPriority();
 
     void incrementAcceptorPriority();

--- a/src/main/java/de/kwantux/networks/config/Config.java
+++ b/src/main/java/de/kwantux/networks/config/Config.java
@@ -1,13 +1,13 @@
 package de.kwantux.networks.config;
 
 import de.kwantux.config.Configuration;
-import de.kwantux.networks.Main;
-import de.kwantux.networks.compat.ConfigurationTransformers;
-import de.kwantux.networks.storage.NetworkProperties;
 import de.kwantux.config.ConfigurationManager;
 import de.kwantux.config.util.exceptions.ConfigAlreadyRegisteredException;
 import de.kwantux.config.util.exceptions.InvalidNodeException;
+import de.kwantux.networks.Main;
+import de.kwantux.networks.compat.ConfigurationTransformers;
 import de.kwantux.networks.component.ComponentType;
+import de.kwantux.networks.storage.NetworkProperties;
 import de.kwantux.networks.utils.BlockLocation;
 import org.bukkit.Material;
 import org.jetbrains.annotations.Nullable;
@@ -60,8 +60,9 @@ public class Config {
             loadChunks = config.getFinalBoolean("performance.loadChunks");
             autoSaveInterval = config.getFinalInt("autoSave");
             commands = config.getFinalList("commands", String.class).toArray(new String[0]);
+            ranges = config.getList("range", Integer.class).toArray(new Integer[0]);
 
-        } catch (ConfigAlreadyRegisteredException e) {
+        } catch (ConfigAlreadyRegisteredException | InvalidNodeException e) {
             throw new RuntimeException(e);
         }
     }
@@ -82,6 +83,7 @@ public class Config {
      */
     public static int autoSaveInterval;
     public static String[] commands;
+    public static Integer[] ranges;
 
 
     public void setLanguage(String language) {
@@ -118,17 +120,6 @@ public class Config {
                 config.getFinalInt("properties.maxComponents"),
                 config.getFinalInt("properties.maxUsers")
         );
-    }
-
-
-    public Integer[] getMaxRanges() {
-        try {
-            return config.getList("range", Integer.class).toArray(new Integer[0]);
-        } catch (InvalidNodeException e) {
-            throw new RuntimeException(e);
-        } catch (SerializationException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public Material getComponentUpgradeMaterial() {

--- a/src/main/java/de/kwantux/networks/event/ComponentListener.java
+++ b/src/main/java/de/kwantux/networks/event/ComponentListener.java
@@ -24,7 +24,6 @@ public class ComponentListener implements Listener {
     public ComponentListener(Main plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
         this.manager = plugin.getNetworkManager();
-        Sorter.setConfig(plugin.getConfiguration());
     }
 
     private void check(@Nullable org.bukkit.Location location) {

--- a/src/main/java/de/kwantux/networks/event/NoticeListener.java
+++ b/src/main/java/de/kwantux/networks/event/NoticeListener.java
@@ -1,6 +1,7 @@
 package de.kwantux.networks.event;
 
 import de.kwantux.networks.Main;
+import de.kwantux.networks.config.Config;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -22,6 +23,7 @@ public class NoticeListener implements Listener {
 
     @EventHandler
     public void onInventoryOpen(InventoryCloseEvent event) {
+        if (!Config.noticeEnabled) return;
         if (event.getInventory().firstEmpty() != -1) return;
         if (notices.contains(event.getPlayer().getUniqueId())) return;
         if (mgr.withUser(event.getPlayer().getUniqueId()).isEmpty()) {

--- a/src/main/java/de/kwantux/networks/event/WandListener.java
+++ b/src/main/java/de/kwantux/networks/event/WandListener.java
@@ -10,9 +10,7 @@ import de.kwantux.networks.component.module.Acceptor;
 import de.kwantux.networks.component.module.Donator;
 import de.kwantux.networks.component.module.Requestor;
 import de.kwantux.networks.component.util.FilterTranslator;
-import de.kwantux.networks.config.CraftingManager;
 import de.kwantux.networks.utils.BlockLocation;
-import de.kwantux.networks.utils.DoubleChestUtils;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.HoverEvent;
 import org.bukkit.Material;
@@ -26,11 +24,8 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 
-import static de.kwantux.networks.Main.lang;
-import static de.kwantux.networks.Main.dcu;
-import static de.kwantux.networks.Main.cfg;
-import static de.kwantux.networks.Main.crf;
-import static de.kwantux.networks.Main.mgr;
+import static de.kwantux.networks.Main.*;
+import static de.kwantux.networks.config.Config.ranges;
 
 public class WandListener implements Listener {
 
@@ -168,7 +163,7 @@ public class WandListener implements Listener {
                             donator.rangeUp();
                             lang.message(p, "rangeupgrade.success", String.valueOf(tier+1), component.pos().toString());
                         }
-                        if (tier == cfg.getMaxRanges().length) {
+                        if (tier == ranges.length) {
                             lang.message(p, "rangeupgrade.last");
                             return;
                         }
@@ -189,7 +184,7 @@ public class WandListener implements Listener {
                             requestor.rangeUp();
                             lang.message(p, "rangeupgrade.success", String.valueOf(tier), component.pos().toString());
                         }
-                        if (tier == cfg.getMaxRanges().length) {
+                        if (tier == ranges.length) {
                             lang.message(p, "rangeupgrade.last");
                             return;
                         }

--- a/src/main/java/de/kwantux/networks/utils/DoubleChestUtils.java
+++ b/src/main/java/de/kwantux/networks/utils/DoubleChestUtils.java
@@ -98,6 +98,6 @@ public class DoubleChestUtils {
                     return new BlockLocation(location.getX(), location.getY(), location.getZ()-1, location.getWorld());
             }
         }
-        return null;
+        return location;
     }
 }


### PR DESCRIPTION
- Fixes that under the transmission of mulitple identical stacks, only one of them will be added to the output container while all are removed from the input.

- The config value for the notification now actually has an effect
