### PR TITLE
Fixed that some wand actions didn't work on proxy components

### DIFF
--- a/src/main/java/de/kwantux/networks/Manager.java
+++ b/src/main/java/de/kwantux/networks/Manager.java
@@ -1,12 +1,12 @@
 package de.kwantux.networks;
 
 
-import de.kwantux.networks.component.util.FilterTranslator;
-import de.kwantux.networks.utils.DoubleChestUtils;
 import de.kwantux.networks.component.ComponentType;
 import de.kwantux.networks.component.NetworkComponent;
+import de.kwantux.networks.component.util.FilterTranslator;
 import de.kwantux.networks.storage.Storage;
 import de.kwantux.networks.utils.BlockLocation;
+import de.kwantux.networks.utils.DoubleChestUtils;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -26,7 +26,6 @@ public final class Manager implements de.kwantux.networks.api.Manager {
     private HashMap<BlockLocation, Network> locations = new HashMap<>();
 
     private HashMap<CommandSender, Network> selections = new HashMap<>();
-    private final ArrayList<UUID> noticedPlayers = new ArrayList<>();
     private final ArrayList<UUID> forceMode = new ArrayList<>();
     private final Logger logger;
 

--- a/src/main/java/de/kwantux/networks/Network.java
+++ b/src/main/java/de/kwantux/networks/Network.java
@@ -1,8 +1,8 @@
 package de.kwantux.networks;
 
+import de.kwantux.networks.component.NetworkComponent;
 import de.kwantux.networks.component.module.Acceptor;
 import de.kwantux.networks.component.module.Supplier;
-import de.kwantux.networks.component.NetworkComponent;
 import de.kwantux.networks.storage.NetworkProperties;
 import de.kwantux.networks.storage.SerializableNetwork;
 import de.kwantux.networks.utils.BlockLocation;
@@ -103,6 +103,9 @@ public class Network {
         return acceptors.stream().sorted(Comparator.comparingInt(Acceptor::acceptorPriority).reversed()).toList();
     }
 
+    /**
+     * ONLY FOR INTERNAL USAGE AND IN {@link de.kwantux.networks.Manager#getComponent(BlockLocation)}
+     */
     public NetworkComponent getComponent(BlockLocation location) {
         for (NetworkComponent component : components) {
             if (component.pos().equals(location)) {

--- a/src/main/java/de/kwantux/networks/event/WandListener.java
+++ b/src/main/java/de/kwantux/networks/event/WandListener.java
@@ -67,7 +67,7 @@ public class WandListener implements Listener {
                 if (l == null) return;
                 NetworkComponent component = dcu.componentAt(l);
                 Network network = null;
-                if (component != null) network = mgr.getNetworkWithComponent(component.pos());
+                if (component != null) network = dcu.networkWithComponentAt(component.pos());
 
                 if (!p.isSneaking()) {
                     if (action.equals(Action.RIGHT_CLICK_BLOCK)) {
@@ -96,8 +96,8 @@ public class WandListener implements Listener {
                 ItemStack itemInOffHand = p.getInventory().getItemInOffHand();
                 if (action.equals(Action.RIGHT_CLICK_BLOCK)) {
 
-                    if (mode == 0 && !itemInOffHand.getType().equals(Material.AIR) && mgr.getComponent(l) instanceof SortingContainer) {
-                        NetworkComponent c = mgr.getComponent(l);
+                    if (mode == 0 && !itemInOffHand.getType().equals(Material.AIR) && dcu.componentAt(l) instanceof SortingContainer) {
+                        NetworkComponent c = dcu.componentAt(l);
                         if (c instanceof SortingContainer container) {
                             container.addFilter(itemInOffHand.getType().ordinal());
                             lang.message(p, "component.sorting.setitem", l.toString(), itemInOffHand.getType().toString());
@@ -109,8 +109,8 @@ public class WandListener implements Listener {
                             lang.message(p, "component.priority", String.valueOf(container.acceptorPriority()));
                         }
                     }
-                    if (mode == 2 && !itemInOffHand.getType().equals(Material.AIR) && mgr.getComponent(l) instanceof SortingContainer) {
-                        NetworkComponent c = mgr.getComponent(l);
+                    if (mode == 2 && !itemInOffHand.getType().equals(Material.AIR) && dcu.componentAt(l) instanceof SortingContainer) {
+                        NetworkComponent c = dcu.componentAt(l);
                         if (c instanceof SortingContainer container) {
                             int hash = itemInOffHand.getItemMeta().hashCode();
                             container.addFilter(hash);
@@ -126,8 +126,8 @@ public class WandListener implements Listener {
 
                 if (action.equals(Action.LEFT_CLICK_BLOCK)) {
 
-                    if ((mode == 0 || mode == 2) && mgr.getComponent(l) instanceof SortingContainer && !itemInOffHand.getType().equals(Material.AIR) && p.isSneaking()) {
-                        NetworkComponent c = mgr.getComponent(l);
+                    if ((mode == 0 || mode == 2) && dcu.componentAt(l) instanceof SortingContainer && !itemInOffHand.getType().equals(Material.AIR) && p.isSneaking()) {
+                        NetworkComponent c = dcu.componentAt(l);
                         if (c instanceof SortingContainer container) {
                             int hash = itemInOffHand.getItemMeta().hashCode();
                             container.removeFilter(itemInOffHand.getType().ordinal());
@@ -148,7 +148,7 @@ public class WandListener implements Listener {
             if (p.getInventory().getItemInMainHand().getItemMeta().getPersistentDataContainer().has(new NamespacedKey("networks", "upgrade.range"), PersistentDataType.INTEGER)) {
                 if (action.equals(Action.RIGHT_CLICK_BLOCK)) {
                     event.setCancelled(true);
-                    NetworkComponent component = mgr.getComponent(l);
+                    NetworkComponent component = dcu.componentAt(l);
                     if (component == null) {
                         lang.message(p, "component.nocomponent");
                         return;

--- a/src/main/java/de/kwantux/networks/utils/DoubleChestUtils.java
+++ b/src/main/java/de/kwantux/networks/utils/DoubleChestUtils.java
@@ -1,6 +1,7 @@
 package de.kwantux.networks.utils;
 
 import de.kwantux.networks.Manager;
+import de.kwantux.networks.Network;
 import de.kwantux.networks.component.NetworkComponent;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -23,6 +24,16 @@ public class DoubleChestUtils {
         }
         return component;
     }
+
+    public Network networkWithComponentAt(BlockLocation pos) {
+        Network network = net.getNetworkWithComponent(pos);
+        if (network == null && pos.getBlock().getType().equals(Material.CHEST)) {
+            Chest chest = (Chest) pos.getBlock().getBlockData();
+            network = net.getNetworkWithComponent(shift(pos, chest.getType(), chest.getFacing()));
+        }
+        return network;
+    }
+
 
     public void checkChest(BlockLocation pos) {
 


### PR DESCRIPTION
Fixed that certain wand actions didn't work on proxy components (the vanilla half of a double chest component)