### PR TITLE
Deleting a network removes the player's selection.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 runPaper.folia.registerTask()
 
 group = "de.kwantux"
-version = "3.0.7"
+version = "3.0.9"
 description = "A performance friendly way to sort your items"
 
 repositories {

--- a/src/main/java/de/kwantux/networks/commands/NetworksCommand.java
+++ b/src/main/java/de/kwantux/networks/commands/NetworksCommand.java
@@ -335,7 +335,12 @@ public class NetworksCommand extends CommandHandler {
         }
 
         mgr.delete(network.name());
-        mgr.select(player, null);
+        // If player had network selected
+        if (mgr.selection(player).name().equals(network.name())) {
+            // Remove their selection
+            mgr.select(player, null);
+        }
+
         lang.message(player, "delete.success", network.name());
     }
 

--- a/src/main/java/de/kwantux/networks/commands/NetworksCommand.java
+++ b/src/main/java/de/kwantux/networks/commands/NetworksCommand.java
@@ -335,6 +335,7 @@ public class NetworksCommand extends CommandHandler {
         }
 
         mgr.delete(network.name());
+        mgr.select(player, null);
         lang.message(player, "delete.success", network.name());
     }
 


### PR DESCRIPTION
When deleting a network, the owner's selected network is reset.


Should we also deselect network for users of the deleted network?