### PR TITLE
Update 3.0.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 runPaper.folia.registerTask()
 
 group = "de.kwantux"
-version = "3.0.10"
+version = "3.0.11"
 description = "A performance friendly way to sort your items"
 
 repositories {

--- a/src/main/java/de/kwantux/networks/Network.java
+++ b/src/main/java/de/kwantux/networks/Network.java
@@ -17,6 +17,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
+import static de.kwantux.networks.config.Config.ranges;
+
 public class Network {
     private String id;
 
@@ -195,4 +197,16 @@ public class Network {
     public int range() {
         return range;
     }
+
+    public int rangeTier() {
+        for (int i = 0; i < ranges.length; i++) {
+            if (range <= ranges[i]) return i;
+        }
+        return ranges.length-1;
+    }
+
+    public void range(int range) {
+        this.range = range;
+    }
+
 }

--- a/src/main/java/de/kwantux/networks/component/module/Acceptor.java
+++ b/src/main/java/de/kwantux/networks/component/module/Acceptor.java
@@ -16,7 +16,7 @@ public interface Acceptor extends PassiveModule {
                 if (item.isSimilar(stack)
                     || item.isSimilar(stack)) {
                     amount -=                        // Decrease the amount of items that need to be transmitted
-                            (64 - item.getAmount()); // by the amount of items that can be put into the slot
+                            (item.getMaxStackSize() - item.getAmount()); // by the amount of items that can be put into the slot
                     if (amount <= 0) return true;
                 }
             }

--- a/src/main/java/de/kwantux/networks/config/Config.java
+++ b/src/main/java/de/kwantux/networks/config/Config.java
@@ -45,6 +45,7 @@ public class Config {
             config.require("humanReadableJson");
             config.require("archiveNetworksOnDelete");
             config.require("autoSave");
+            config.require("rangePerNetwork");
 
             ConfigurationTransformers.generalConfigTransformers(config);
 
@@ -61,6 +62,7 @@ public class Config {
             autoSaveInterval = config.getFinalInt("autoSave");
             commands = config.getFinalList("commands", String.class).toArray(new String[0]);
             ranges = config.getList("range", Integer.class).toArray(new Integer[0]);
+            rangePerNetwork = config.getFinalBoolean("rangePerNetwork");
 
         } catch (ConfigAlreadyRegisteredException | InvalidNodeException e) {
             throw new RuntimeException(e);
@@ -78,6 +80,7 @@ public class Config {
     public static boolean complexInventoryChecks;
     public static boolean propertyLore;
     public static boolean loadChunks;
+    public static boolean rangePerNetwork;
     /**
      * Auto save interval in seconds
      */

--- a/src/main/java/de/kwantux/networks/event/ComponentListener.java
+++ b/src/main/java/de/kwantux/networks/event/ComponentListener.java
@@ -17,6 +17,8 @@ import org.bukkit.event.inventory.InventoryPickupItemEvent;
 
 import javax.annotation.Nullable;
 
+import static de.kwantux.networks.Main.dcu;
+
 public class ComponentListener implements Listener {
 
     private Manager manager;
@@ -29,7 +31,7 @@ public class ComponentListener implements Listener {
     private void check(@Nullable org.bukkit.Location location) {
         if (location == null) return;
         BlockLocation loc = new BlockLocation(location);
-        NetworkComponent component = manager.getComponent(loc);
+        NetworkComponent component = dcu.componentAt(loc);
         if (component != null) {
             if (component instanceof Donator donator) {
                 Network network = manager.getNetworkWithComponent(component.pos());

--- a/src/main/java/de/kwantux/networks/event/WandListener.java
+++ b/src/main/java/de/kwantux/networks/event/WandListener.java
@@ -7,9 +7,9 @@ import de.kwantux.networks.commands.NetworksCommand;
 import de.kwantux.networks.component.NetworkComponent;
 import de.kwantux.networks.component.component.SortingContainer;
 import de.kwantux.networks.component.module.Acceptor;
-import de.kwantux.networks.component.module.Donator;
-import de.kwantux.networks.component.module.Requestor;
+import de.kwantux.networks.component.module.ActiveModule;
 import de.kwantux.networks.component.util.FilterTranslator;
+import de.kwantux.networks.config.Config;
 import de.kwantux.networks.utils.BlockLocation;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -219,65 +219,54 @@ public class WandListener implements Listener {
                 if (action.equals(Action.RIGHT_CLICK_BLOCK)) {
                     event.setCancelled(true);
                     NetworkComponent component = dcu.componentAt(l);
+                    Network network = dcu.networkWithComponentAt(l);
                     if (component == null) {
                         lang.message(p, "component.nocomponent");
                         return;
                     }
-                    if (component instanceof Donator donator) {
-                        int tier = donator.range();
-                        int upgradeTier = p.getInventory().getItemInMainHand().getItemMeta().getPersistentDataContainer().get(new NamespacedKey("networks", "upgrade.range"), PersistentDataType.INTEGER)-1;
 
-                        if (upgradeTier == tier) {
-                            ItemStack item = p.getInventory().getItemInMainHand();
-                            item.setAmount(item.getAmount() - 1);
-                            donator.rangeUp();
-                            lang.message(p, "rangeupgrade.success", String.valueOf(tier+1), component.pos().toString());
-                        }
-                        if (tier == ranges.length) {
-                            lang.message(p, "rangeupgrade.last");
-                            return;
-                        }
-                        if (tier > ranges.length || tier < 0) {
-                            lang.message(p, "rangeupgrade.invalid");
-                            return;
-                        }
-                        if (upgradeTier < tier) {
-                            lang.message(p, "rangeupgrade.alreadyupgraded", String.valueOf(tier));
-                        }
-                        if (upgradeTier > tier) {
-                            lang.message(p, "rangeupgrade.unlockfirst", String.valueOf(tier));
-                        }
+                    int tier;
+                    Runnable rangeUp;
+
+                    if (Config.rangePerNetwork) {
+                        tier = network.rangeTier();
+                        rangeUp = () -> network.range(ranges[tier+1]);
                     }
-                    else if (component instanceof Requestor requestor) {
-                        int tier = requestor.range();
-                        int upgradeTier = p.getInventory().getItemInMainHand().getItemMeta().getPersistentDataContainer().get(new NamespacedKey("networks", "upgrade.range"), PersistentDataType.INTEGER);
-
-                        if (upgradeTier == tier) {
-                            ItemStack item = p.getInventory().getItemInMainHand();
-                            item.setAmount(item.getAmount() - 1);
-                            requestor.rangeUp();
-                            lang.message(p, "rangeupgrade.success", String.valueOf(tier), component.pos().toString());
-                        }
-                        if (tier == ranges.length) {
-                            lang.message(p, "rangeupgrade.last");
-                            return;
-                        }
-                        if (tier > ranges.length || tier < 0) {
-                            lang.message(p, "rangeupgrade.invalid");
-                            return;
-                        }
-                        if (upgradeTier < tier) {
-                            lang.message(p, "rangeupgrade.alreadyupgraded", String.valueOf(tier));
-                        }
-                        if (upgradeTier > tier) {
-                            lang.message(p, "rangeupgrade.unlockfirst", String.valueOf(tier));
-                        }
+                    else if (component instanceof ActiveModule module) {
+                        tier = module.range();
+                        rangeUp = module::rangeUp;
                     }
                     else {
                         lang.message(p, "rangeupgrade.passivecomponent");
+                        return;
                     }
 
-                    
+                    int upgradeTier = p.getInventory().getItemInMainHand().getItemMeta().getPersistentDataContainer().get(new NamespacedKey("networks", "upgrade.range"), PersistentDataType.INTEGER)-1;
+
+                    if (upgradeTier == tier) {
+                        ItemStack item = p.getInventory().getItemInMainHand();
+                        item.setAmount(item.getAmount() - 1);
+                        rangeUp.run();
+                        if (Config.rangePerNetwork)
+                            lang.message(p, "rangeupgrade.success.network", String.valueOf(tier+1), network.name());
+                        else lang.message(p, "rangeupgrade.success", String.valueOf(tier+1), component.pos().toString());
+                    }
+                    if (tier == ranges.length) {
+                        lang.message(p, "rangeupgrade.last");
+                        return;
+                    }
+                    if (tier > ranges.length || tier < 0) {
+                        lang.message(p, "rangeupgrade.invalid");
+                        return;
+                    }
+                    if (upgradeTier < tier) {
+                        lang.message(p, "rangeupgrade.alreadyupgraded", String.valueOf(tier));
+                    }
+                    if (upgradeTier > tier) {
+                        lang.message(p, "rangeupgrade.unlockfirst", String.valueOf(tier+1));
+                    }
+
+
                 }
             }
         }

--- a/src/main/java/de/kwantux/networks/event/WandListener.java
+++ b/src/main/java/de/kwantux/networks/event/WandListener.java
@@ -237,6 +237,10 @@ public class WandListener implements Listener {
                             lang.message(p, "rangeupgrade.last");
                             return;
                         }
+                        if (tier > ranges.length || tier < 0) {
+                            lang.message(p, "rangeupgrade.invalid");
+                            return;
+                        }
                         if (upgradeTier < tier) {
                             lang.message(p, "rangeupgrade.alreadyupgraded", String.valueOf(tier));
                         }
@@ -256,6 +260,10 @@ public class WandListener implements Listener {
                         }
                         if (tier == ranges.length) {
                             lang.message(p, "rangeupgrade.last");
+                            return;
+                        }
+                        if (tier > ranges.length || tier < 0) {
+                            lang.message(p, "rangeupgrade.invalid");
                             return;
                         }
                         if (upgradeTier < tier) {

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -1,4 +1,4 @@
-# Networks v3.0.10
+# Networks v3.0.11
 
 
 ## Report any bugs on Discord or Github

--- a/src/main/resources/general.conf
+++ b/src/main/resources/general.conf
@@ -12,7 +12,6 @@ component {
   input = [ "CHEST", "TRAPPED_CHEST", "BARREL", "HOPPER", "DISPENSER", "DROPPER" ]
   sorting = [ "CHEST", "TRAPPED_CHEST", "BARREL", "HOPPER", "DISPENSER", "DROPPER" ]
   misc = [ "CHEST", "TRAPPED_CHEST", "BARREL", "HOPPER", "DISPENSER", "DROPPER" ]
-  #furnace = [ "furnace", "blast_furnace", "smoke_furnace" ]
 }
 
 # Auto-save interval in seconds
@@ -85,6 +84,8 @@ archiveNetworksOnDelete = false
 # Values Must be integers between -1 and 2147483647
 range = [0, 50, 100, 200, 500, -1]
 
+# Whether range upgrades are per component or per network
+rangePerNetwork = false
 
 # The maximum amount of networks a player can own
 maxNetworks = 5

--- a/src/main/resources/lang/de.yml
+++ b/src/main/resources/lang/de.yml
@@ -129,6 +129,7 @@ rangeupgrade.last: <prefix><yellow>Du hast bereits die höchste Stufe erreicht.
 rangeupgrade.alreadyupgraded: <prefix><yellow>Diese Erweiterung hast du bereits installiert, die nächste Stufe ist <white>Telemetrie Antenne Mk.<1>
 rangeupgrade.unlockfirst: <prefix><yellow>Du musst zuerst Stufe <white><1><yellow> freischalten!
 rangeupgrade.passivecomponent: <prefix><yellow>Dieses Upgrade ist nur für <bold>aktive</bold> Komponenten (z.B. Einfüllkisten), jedoch nicht für passiven Komponenten (z.B. Sortierkisten, Restekisten) nutzbar.
+rangeupgrade.invalid: <prefix><yellow>Diese Upgrade Stufe existiert nicht, wahrscheinlich wurde die Plugin-Konfiguration geändert nachdem du dieses Item gecrafted hast.
 rangeupgrade.success: <prefix>Reichweite <1> wurde am Komponenten <2> installiert!
 
 user.add: <prefix>Spieler <2> wurde zum Netzwerk <1> hinzugefügt

--- a/src/main/resources/lang/de.yml
+++ b/src/main/resources/lang/de.yml
@@ -131,6 +131,7 @@ rangeupgrade.unlockfirst: <prefix><yellow>Du musst zuerst Stufe <white><1><yello
 rangeupgrade.passivecomponent: <prefix><yellow>Dieses Upgrade ist nur für <bold>aktive</bold> Komponenten (z.B. Einfüllkisten), jedoch nicht für passiven Komponenten (z.B. Sortierkisten, Restekisten) nutzbar.
 rangeupgrade.invalid: <prefix><yellow>Diese Upgrade Stufe existiert nicht, wahrscheinlich wurde die Plugin-Konfiguration geändert nachdem du dieses Item gecrafted hast.
 rangeupgrade.success: <prefix>Reichweite <1> wurde am Komponenten <2> installiert!
+rangeupgrade.success.network: <prefix>Reichweite <1> wurde am Netzwerk <2> installiert!
 
 user.add: <prefix>Spieler <2> wurde zum Netzwerk <1> hinzugefügt
 user.add.nochange: <prefix>Spieler <2> wurde bereits zum Netzwerk <1> hinzugefügt

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -129,6 +129,7 @@ location.occupied: <prefix><red>There is already a component at this location!
 rangeupgrade.last: <prefix><yellow>You already reached the maximum upgrade level.
 rangeupgrade.alreadyupgraded: <prefix><yellow>You already installed this upgrade, the next upgrade is range Tier <white><1>
 rangeupgrade.unlockfirst: <prefix><yellow>You need to unlock range Tier <white><1><yellow> first!
+rangeupgrade.invalid: <prefix><yellow>You somehow obtained an invalid range upgrade... Possibly your admin changed the config after you crafted this.
 rangeupgrade.passivecomponent: <prefix><yellow>This can only be applied to <bold>active</bold> network components (e.g. Input), NOT passive components (e.g. Sorting, Misc)
 rangeupgrade.success: <prefix>Successfully upgraded component <2> to Tier <1>!
 

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -132,6 +132,7 @@ rangeupgrade.unlockfirst: <prefix><yellow>You need to unlock range Tier <white><
 rangeupgrade.invalid: <prefix><yellow>You somehow obtained an invalid range upgrade... Possibly your admin changed the config after you crafted this.
 rangeupgrade.passivecomponent: <prefix><yellow>This can only be applied to <bold>active</bold> network components (e.g. Input), NOT passive components (e.g. Sorting, Misc)
 rangeupgrade.success: <prefix>Successfully upgraded component <2> to Tier <1>!
+rangeupgrade.success.network: <prefix>Successfully upgraded network <2> to Tier <1>!
 
 user.add: <prefix>Successfully added <2> to the network <1>
 user.remove: <prefix>Successfully removed <2> from the network <1>
@@ -228,6 +229,7 @@ item.lore.component.misc.upgrade:
   - "<reset><blue>All remaining items will go into these"
 
 item.lore.upgrade.range:
-  - "<reset>Click on a network component to apply this upgrade on its network"
+  - "<reset>Click on a network component to apply this upgrade"
+  - "<reset>Depending on this server's config this applies to all components in the network or just that single component"
 
 notice: <yellow>Having inventory problems? Try out <white>/networks <yellow>to constructor a fully automated storage network!


### PR DESCRIPTION
- adds an option to increase the entire network's range instead of just the component's one. 
- fixed that the complex inventory check would incorrectly return that the inventory has free space if it's filled with unstackable items
- fixed that double input chests didn't trigger a donation event if the component part of the double chest was facing west or south